### PR TITLE
fix: Use a more performant HTML tag finding regex (fix #3035)

### DIFF
--- a/apps/editor/src/__test__/unit/helper/common.spec.ts
+++ b/apps/editor/src/__test__/unit/helper/common.spec.ts
@@ -1,4 +1,4 @@
-import { deepCopy, deepCopyArray, deepMergedCopy, includes } from '@/utils/common';
+import { deepCopy, deepCopyArray, deepMergedCopy, includes, escape } from '@/utils/common';
 
 it('"deepCopy" should copy the object deeply', () => {
   const obj = { foo: 1, bar: { baz: 1 } };
@@ -24,4 +24,27 @@ it('"deepMergedCopy" should merge the objects and copy them deeply', () => {
 
 it('"includes" should check whether the specific element is inlcuded in array', () => {
   expect(includes([1, 2, 3], 1)).toBe(true);
+});
+
+describe('escape', () => {
+  // This one has a lot of characters after the '<' symbol to make it timeout the jest test if it regresses
+  it('should not break on < chars', () => {
+    expect(
+      escape(
+        'foo <bar. The quick brown fox jumped over the lazy dogs. Lorem ipsum dolor es sit. Lorem impsum dolor es sit. Lorem ipsum dolor es sit. Lorem impsum dolor es sit'
+      )
+    ).toEqual(
+      'foo <bar. The quick brown fox jumped over the lazy dogs. Lorem ipsum dolor es sit. Lorem impsum dolor es sit. Lorem ipsum dolor es sit. Lorem impsum dolor es sit'
+    );
+  });
+
+  it('should escape HTML', () => {
+    expect(escape('Foo <a href="bar">baz</a> quux')).toEqual('Foo \\<a href="bar">baz\\</a> quux');
+  });
+
+  it("should escape HTML even if there's a comment", () => {
+    expect(escape('Foo <a href="bar">baz</a><!-- this is a comment --> quux')).toEqual(
+      'Foo \\<a href="bar">baz\\</a>\\<!-- this is a comment --> quux'
+    );
+  });
 });

--- a/apps/editor/src/utils/common.ts
+++ b/apps/editor/src/utils/common.ts
@@ -8,7 +8,7 @@ import { LinkAttributeNames, LinkAttributes } from '@t/editor';
 export const isMac = /Mac/.test(navigator.platform);
 const reSpaceMoreThanOne = /[\u0020]+/g;
 const reEscapeChars = /[>(){}[\]+-.!#|]/g;
-const reEscapeHTML = /<([a-zA-Z_][a-zA-Z0-9\-._]*)(\s|[^\\>])*\/?>|<(\/)([a-zA-Z_][a-zA-Z0-9\-._]*)\s*\/?>|<!--[^-]+-->|<([a-zA-Z_][a-zA-Z0-9\-.:/]*)>/g;
+const reEscapeHTML = /<(?:"[^"]*"['"]*|'[^']*'['"]*|[^'">])+>/g;
 const reEscapeBackSlash = /\\[!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~\\]/g;
 const reEscapePairedChars = /[*_~`]/g;
 const reMdImageSyntax = /!\[.*\]\(.*\)/g;


### PR DESCRIPTION
The regex for finding HTML tags was locking up the browser if a pasted string contained a '<' character without a matching '>' character. Change the regex, and add tests to ensure that the HTML escaping works the same as before.

<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [ ] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description



---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
